### PR TITLE
added preprocessor directive for proper import of opus brew package

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -11,7 +11,11 @@ import (
 
 /*
 #cgo pkg-config: opus
+#ifdef __APPLE__
+#include <opus.h>
+#else
 #include <opus/opus.h>
+#endif
 */
 import "C"
 

--- a/encoder.go
+++ b/encoder.go
@@ -11,7 +11,11 @@ import (
 
 /*
 #cgo pkg-config: opus
+#ifdef __APPLE__
+#include <opus.h>
+#else
 #include <opus/opus.h>
+#endif
 
 int
 bridge_encoder_set_dtx(OpusEncoder *st, opus_int32 use_dtx)

--- a/errors.go
+++ b/errors.go
@@ -10,7 +10,11 @@ import (
 
 /*
 #cgo pkg-config: opus opusfile
+#ifdef __APPLE__
+#include <opus.h>
+#else
 #include <opus/opus.h>
+#endif
 #include <opusfile.h>
 
 // Access the preprocessor from CGO

--- a/opus.go
+++ b/opus.go
@@ -7,7 +7,11 @@ package opus
 /*
 // Link opus using pkg-config.
 #cgo pkg-config: opus
+#ifdef __APPLE__
+#include <opus.h>
+#else
 #include <opus/opus.h>
+#endif
 
 // Access the preprocessor from CGO
 const int CONST_APPLICATION_VOIP = OPUS_APPLICATION_VOIP;


### PR DESCRIPTION
Hi, 

there seems to be a difference in the installation path where the brew packet manager installs on MacOS the opus library.

While on Linux the import statement: 
`#include <opus/opus.h>`
works fine, in MacOS it doesn't. On MacOS the opus.pc which comes with brew is slightly different and requires the following import: 
`#include <opus.h>`

I added preprocessor directive to check the platform and import the correct opus.h from the correct path.