### PR TITLE
Update import path to pkg-config style

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -11,7 +11,7 @@ import (
 
 /*
 #cgo pkg-config: opus
-#include <opus/opus.h>
+#include <opus.h>
 */
 import "C"
 

--- a/encoder.go
+++ b/encoder.go
@@ -11,7 +11,7 @@ import (
 
 /*
 #cgo pkg-config: opus
-#include <opus/opus.h>
+#include <opus.h>
 
 int
 bridge_encoder_set_dtx(OpusEncoder *st, opus_int32 use_dtx)

--- a/errors.go
+++ b/errors.go
@@ -10,7 +10,7 @@ import (
 
 /*
 #cgo pkg-config: opus opusfile
-#include <opus/opus.h>
+#include <opus.h>
 #include <opusfile.h>
 
 // Access the preprocessor from CGO

--- a/opus.go
+++ b/opus.go
@@ -7,7 +7,7 @@ package opus
 /*
 // Link opus using pkg-config.
 #cgo pkg-config: opus
-#include <opus/opus.h>
+#include <opus.h>
 
 // Access the preprocessor from CGO
 const int CONST_APPLICATION_VOIP = OPUS_APPLICATION_VOIP;


### PR DESCRIPTION
pkg-config --cflags always puts you in the opus/ directory where opus.h
directly lives. No need to prefix with opus/. That just happened to work
because it was symlinked into /usr/include/opus, but we don't need to
rely on that now that we're using pkg-config.

Based on Tobias Wellnitz's PR (hraban/opus#12)