### PR TITLE
Forward error correction

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,3 +5,4 @@ relevant license (see the LICENSE file).
 Hraban Luyat <hraban@0brg.net>
 Dejian Xu <xudejian2008@gmail.com>
 Tobias Wellnitz <tobias.wellnitz@gmail.com>
+Elinor Natanzon <stop.start.dev@gmail.com>

--- a/README.md
+++ b/README.md
@@ -108,6 +108,15 @@ for i := 0; i < n; i++ {
 }
 ```
 
+Note regarding Forward Error Correction (FEC):
+> When a packet is considered "lost", `DecodeFEC` and `DecodeFECFloat32` methods
+> can be called on the next packet in order to try and recover some of the lost
+> data. The PCM needs to be exactly the duration of audio that is missing.
+> `LastPacketDuration()` can be used on the decoder to get the length of the
+> last packet.
+> Note also that in order to use this feature the encoder needs to be configured
+> with `SetInBandFEC(true)` and `SetPacketLossPerc(x)` options.
+
 ### Streams (and files)
 
 To decode a .opus file (or .ogg with Opus data), or to decode a "Opus stream"

--- a/decoder.go
+++ b/decoder.go
@@ -113,7 +113,8 @@ func (dec *Decoder) DecodeFloat32(data []byte, pcm []float32) (int, error) {
 }
 
 // DecodeFEC encoded Opus data into the supplied buffer with forward error
-// correction. The supplied buffer will be entirely filled.
+// correction. It is to be used on the packet directly following the lost one.
+// The supplied buffer needs to be exactly the duration of audio that is missing
 func (dec *Decoder) DecodeFEC(data []byte, pcm []int16) error {
 	if dec.p == nil {
 		return errDecUninitialized
@@ -139,7 +140,8 @@ func (dec *Decoder) DecodeFEC(data []byte, pcm []int16) error {
 }
 
 // DecodeFECFloat32 encoded Opus data into the supplied buffer with forward error
-// correction. The supplied buffer will be entirely filled.
+// correction. It is to be used on the packet directly following the lost one.
+// The supplied buffer needs to be exactly the duration of audio that is missing
 func (dec *Decoder) DecodeFECFloat32(data []byte, pcm []float32) error {
 	if dec.p == nil {
 		return errDecUninitialized

--- a/decoder.go
+++ b/decoder.go
@@ -12,6 +12,12 @@ import (
 /*
 #cgo pkg-config: opus
 #include <opus.h>
+
+int
+bridge_decoder_get_last_packet_duration(OpusDecoder *st, opus_int32 *samples)
+{
+	return opus_decoder_ctl(st, OPUS_GET_LAST_PACKET_DURATION(samples));
+}
 */
 import "C"
 
@@ -104,4 +110,14 @@ func (dec *Decoder) DecodeFloat32(data []byte, pcm []float32) (int, error) {
 		return 0, Error(n)
 	}
 	return n, nil
+}
+
+// Gets the duration (in samples) of the last packet successfully decoded or concealed.
+func (dec *Decoder) LastPacketDuration() (int,error){
+	var samples C.opus_int32
+	res := C.bridge_decoder_get_last_packet_duration(dec.p, &samples)
+	if res != C.OPUS_OK {
+		return 0, Error(res)
+	}
+	return int(samples), nil
 }

--- a/decoder.go
+++ b/decoder.go
@@ -138,6 +138,31 @@ func (dec *Decoder) DecodeFEC(data []byte, pcm []int16) error {
 	return nil
 }
 
+// Decode encoded Opus data into the supplied buffer with forward error
+// correction. The supplied buffer will be entirely filled.
+func (dec *Decoder) DecodeFECFloat32(data []byte, pcm []float32) error {
+	if dec.p == nil {
+		return errDecUninitialized
+	}
+	if len(data) == 0 {
+		return fmt.Errorf("opus: no data supplied")
+	}
+	if len(pcm) == 0 {
+		return fmt.Errorf("opus: target buffer empty")
+	}
+	n := int(C.opus_decode_float(
+		dec.p,
+		(*C.uchar)(&data[0]),
+		C.opus_int32(len(data)),
+		(*C.float)(&pcm[0]),
+		C.int(cap(pcm)),
+		1))
+	if n < 0 {
+		return Error(n)
+	}
+	return nil
+}
+
 // Gets the duration (in samples) of the last packet successfully decoded or concealed.
 func (dec *Decoder) LastPacketDuration() (int, error) {
 	var samples C.opus_int32

--- a/decoder.go
+++ b/decoder.go
@@ -112,7 +112,7 @@ func (dec *Decoder) DecodeFloat32(data []byte, pcm []float32) (int, error) {
 	return n, nil
 }
 
-// Decode encoded Opus data into the supplied buffer with forward error
+// DecodeFEC encoded Opus data into the supplied buffer with forward error
 // correction. The supplied buffer will be entirely filled.
 func (dec *Decoder) DecodeFEC(data []byte, pcm []int16) error {
 	if dec.p == nil {
@@ -138,7 +138,7 @@ func (dec *Decoder) DecodeFEC(data []byte, pcm []int16) error {
 	return nil
 }
 
-// Decode encoded Opus data into the supplied buffer with forward error
+// DecodeFECFloat32 encoded Opus data into the supplied buffer with forward error
 // correction. The supplied buffer will be entirely filled.
 func (dec *Decoder) DecodeFECFloat32(data []byte, pcm []float32) error {
 	if dec.p == nil {
@@ -163,7 +163,8 @@ func (dec *Decoder) DecodeFECFloat32(data []byte, pcm []float32) error {
 	return nil
 }
 
-// Gets the duration (in samples) of the last packet successfully decoded or concealed.
+// LastPacketDuration gets the duration (in samples)
+// of the last packet successfully decoded or concealed.
 func (dec *Decoder) LastPacketDuration() (int, error) {
 	var samples C.opus_int32
 	res := C.bridge_decoder_get_last_packet_duration(dec.p, &samples)

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -30,3 +30,39 @@ func TestDecoderUnitialized(t *testing.T) {
 		t.Errorf("Expected \"unitialized decoder\" error: %v", err)
 	}
 }
+
+func TestDecoder_GetLastPacketDuration(t *testing.T) {
+	const G4 = 391.995
+	const SAMPLE_RATE = 48000
+	const FRAME_SIZE_MS = 60
+	const FRAME_SIZE = SAMPLE_RATE * FRAME_SIZE_MS / 1000
+	pcm := make([]int16, FRAME_SIZE)
+	enc, err := NewEncoder(SAMPLE_RATE, 1, AppVoIP)
+	if err != nil || enc == nil {
+		t.Fatalf("Error creating new encoder: %v", err)
+	}
+	addSine(pcm, SAMPLE_RATE, G4)
+
+	data := make([]byte, 1000)
+	n, err := enc.Encode(pcm, data)
+	if err != nil {
+		t.Fatalf("Couldn't encode data: %v", err)
+	}
+	data = data[:n]
+
+	dec, err := NewDecoder(SAMPLE_RATE, 1)
+	if err != nil || dec == nil {
+		t.Fatalf("Error creating new decoder: %v", err)
+	}
+	n, err = dec.Decode(data, pcm)
+	if err != nil {
+		t.Fatalf("Couldn't decode data: %v", err)
+	}
+	samples, err := dec.LastPacketDuration()
+	if err!=nil{
+		t.Fatalf("Couldn't get last packet duration: %v",err)
+	}
+	if samples!=n{
+		t.Fatalf("Wrong duration length. Expected %d. Got %d", n, samples)
+	}
+}

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -59,10 +59,10 @@ func TestDecoder_GetLastPacketDuration(t *testing.T) {
 		t.Fatalf("Couldn't decode data: %v", err)
 	}
 	samples, err := dec.LastPacketDuration()
-	if err!=nil{
-		t.Fatalf("Couldn't get last packet duration: %v",err)
+	if err != nil {
+		t.Fatalf("Couldn't get last packet duration: %v", err)
 	}
-	if samples!=n{
+	if samples != n {
 		t.Fatalf("Wrong duration length. Expected %d. Got %d", n, samples)
 	}
 }

--- a/encoder.go
+++ b/encoder.go
@@ -68,6 +68,30 @@ bridge_encoder_get_max_bandwidth(OpusEncoder *st, opus_int32 *max_bw)
 	return opus_encoder_ctl(st, OPUS_GET_MAX_BANDWIDTH(max_bw));
 }
 
+int
+bridge_encoder_set_inband_fec(OpusEncoder *st, opus_int32 fec)
+{
+	return opus_encoder_ctl(st, OPUS_SET_INBAND_FEC(fec));
+}
+
+int
+bridge_encoder_get_inband_fec(OpusEncoder *st, opus_int32 *fec)
+{
+	return opus_encoder_ctl(st, OPUS_GET_INBAND_FEC(fec));
+}
+
+int
+bridge_encoder_set_packet_loss_perc(OpusEncoder *st, opus_int32 loss_perc)
+{
+	return opus_encoder_ctl(st, OPUS_SET_PACKET_LOSS_PERC(loss_perc));
+}
+
+int
+bridge_encoder_get_packet_loss_perc(OpusEncoder *st, opus_int32 *loss_perc)
+{
+	return opus_encoder_ctl(st, OPUS_GET_PACKET_LOSS_PERC(loss_perc));
+}
+
 */
 import "C"
 
@@ -300,4 +324,44 @@ func (enc *Encoder) MaxBandwidth() (Bandwidth, error) {
 		return 0, Error(res)
 	}
 	return Bandwidth(maxBw), nil
+}
+
+
+// SetInBandFEC configures the encoder's use of inband forward error
+// correction (FEC)
+func (enc *Encoder) SetInBandFEC(fec int) error {
+	res := C.bridge_encoder_set_inband_fec(enc.p, C.opus_int32(fec))
+	if res != C.OPUS_OK {
+		return Error(res)
+	}
+	return nil
+}
+
+// InBandFEC gets the encoder's configured inband forward error correction (FEC)
+func (enc *Encoder) InBandFEC() (int, error) {
+	var fec C.opus_int32
+	res := C.bridge_encoder_get_inband_fec(enc.p, &fec)
+	if res != C.OPUS_OK {
+		return 0, Error(res)
+	}
+	return int(fec), nil
+}
+
+// SetPacketLossPerc configures the encoder's expected packet loss percentage.
+func (enc *Encoder) SetPacketLossPerc(lossPerc int) error {
+	res := C.bridge_encoder_set_packet_loss_perc(enc.p, C.opus_int32(lossPerc))
+	if res != C.OPUS_OK {
+		return Error(res)
+	}
+	return nil
+}
+
+// PacketLossPerc gets the encoder's configured packet loss percentage.
+func (enc *Encoder) PacketLossPerc() (int, error) {
+	var lossPerc C.opus_int32
+	res := C.bridge_encoder_get_packet_loss_perc(enc.p, &lossPerc)
+	if res != C.OPUS_OK {
+		return 0, Error(res)
+	}
+	return int(lossPerc), nil
 }

--- a/encoder.go
+++ b/encoder.go
@@ -326,11 +326,14 @@ func (enc *Encoder) MaxBandwidth() (Bandwidth, error) {
 	return Bandwidth(maxBw), nil
 }
 
-
 // SetInBandFEC configures the encoder's use of inband forward error
 // correction (FEC)
-func (enc *Encoder) SetInBandFEC(fec int) error {
-	res := C.bridge_encoder_set_inband_fec(enc.p, C.opus_int32(fec))
+func (enc *Encoder) SetInBandFEC(fec bool) error {
+	i := 0
+	if fec {
+		i = 1
+	}
+	res := C.bridge_encoder_set_inband_fec(enc.p, C.opus_int32(i))
 	if res != C.OPUS_OK {
 		return Error(res)
 	}
@@ -338,13 +341,13 @@ func (enc *Encoder) SetInBandFEC(fec int) error {
 }
 
 // InBandFEC gets the encoder's configured inband forward error correction (FEC)
-func (enc *Encoder) InBandFEC() (int, error) {
+func (enc *Encoder) InBandFEC() (bool, error) {
 	var fec C.opus_int32
 	res := C.bridge_encoder_get_inband_fec(enc.p, &fec)
 	if res != C.OPUS_OK {
-		return 0, Error(res)
+		return false, Error(res)
 	}
-	return int(fec), nil
+	return fec != 0, nil
 }
 
 // SetPacketLossPerc configures the encoder's expected packet loss percentage.

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -259,3 +259,57 @@ func TestEncoder_SetGetMaxBandwidth(t *testing.T) {
 		}
 	}
 }
+
+func TestEncoder_SetGetInBandFEC(t *testing.T) {
+	enc, err := NewEncoder(8000, 1, AppVoIP)
+	if err != nil || enc == nil {
+		t.Errorf("Error creating new encoder: %v", err)
+	}
+
+
+	if err := enc.SetInBandFEC(1); err != nil {
+		t.Error("Error setting fec:", err)
+	}
+
+	fec, err := enc.InBandFEC()
+	if err != nil {
+		t.Error("Error getting fec", err)
+	}
+	if fec !=1{
+		t.Error("Wrong fec value ")
+	}
+
+	if err := enc.SetInBandFEC(0); err != nil {
+		t.Error("Error setting fec:", err)
+	}
+
+	fec, err = enc.InBandFEC()
+	if err != nil {
+		t.Error("Error getting fec", err)
+	}
+	if fec !=0{
+		t.Error("Wrong fec value")
+	}
+}
+
+func TestEncoder_SetGetPacketLossPerc(t *testing.T) {
+	enc, err := NewEncoder(8000, 1, AppVoIP)
+	if err != nil || enc == nil {
+		t.Errorf("Error creating new encoder: %v", err)
+	}
+	vals := []int{0, 5, 10, 20}
+	for _, lossPerc := range vals {
+		err := enc.SetPacketLossPerc(lossPerc)
+		if err != nil {
+			t.Error("Error setting loss percentage value:", err)
+		}
+		lp, err := enc.PacketLossPerc()
+		if err != nil {
+			t.Error("Error getting loss percentage value", err)
+		}
+		if lp != lossPerc {
+			t.Errorf("Unexpected encoder loss percentage value. Got %d, but expected %d",
+				lp, lossPerc)
+		}
+	}
+}

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -312,3 +312,26 @@ func TestEncoder_SetGetPacketLossPerc(t *testing.T) {
 		}
 	}
 }
+
+func TestEncoder_SetGetInvalidPacketLossPerc(t *testing.T) {
+	enc, err := NewEncoder(8000, 1, AppVoIP)
+	if err != nil || enc == nil {
+		t.Errorf("Error creating new encoder: %v", err)
+	}
+	vals := []int{-1, 101}
+	for _, lossPerc := range vals {
+		err := enc.SetPacketLossPerc(lossPerc)
+		if err == nil {
+			t.Errorf("Expected Error invalid loss percentage: %d", lossPerc)
+		}
+		lp, err := enc.PacketLossPerc()
+		if err != nil {
+			t.Error("Error getting loss percentage value", err)
+		}
+		// default packet loss percentage is 0
+		if lp != 0 {
+			t.Errorf("Unexpected encoder loss percentage value. Got %d, but expected %d",
+				lp, lossPerc)
+		}
+	}
+}

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -266,8 +266,7 @@ func TestEncoder_SetGetInBandFEC(t *testing.T) {
 		t.Errorf("Error creating new encoder: %v", err)
 	}
 
-
-	if err := enc.SetInBandFEC(1); err != nil {
+	if err := enc.SetInBandFEC(true); err != nil {
 		t.Error("Error setting fec:", err)
 	}
 
@@ -275,11 +274,11 @@ func TestEncoder_SetGetInBandFEC(t *testing.T) {
 	if err != nil {
 		t.Error("Error getting fec", err)
 	}
-	if fec !=1{
-		t.Error("Wrong fec value ")
+	if !fec {
+		t.Errorf("Wrong fec value. Expected %t", true)
 	}
 
-	if err := enc.SetInBandFEC(0); err != nil {
+	if err := enc.SetInBandFEC(false); err != nil {
 		t.Error("Error setting fec:", err)
 	}
 
@@ -287,8 +286,8 @@ func TestEncoder_SetGetInBandFEC(t *testing.T) {
 	if err != nil {
 		t.Error("Error getting fec", err)
 	}
-	if fec !=0{
-		t.Error("Wrong fec value")
+	if fec {
+		t.Errorf("Wrong fec value. Expected %t", false)
 	}
 }
 

--- a/opus_test.go
+++ b/opus_test.go
@@ -59,6 +59,90 @@ func TestCodec(t *testing.T) {
 	// passes error codes through, and that's that.
 }
 
+func TestCodecFEC(t *testing.T) {
+	// Create bogus input sound
+	const G4 = 391.995
+	const SAMPLE_RATE = 48000
+	const FRAME_SIZE_MS = 60
+	const FRAME_SIZE = SAMPLE_RATE * FRAME_SIZE_MS / 1000
+	const PACKET_SIZE = 480 // 10ms packet
+	pcm := make([]int16, 0)
+
+	enc, err := NewEncoder(SAMPLE_RATE, 1, AppVoIP)
+	if err != nil || enc == nil {
+		t.Fatalf("Error creating new encoder: %v", err)
+	}
+	enc.SetPacketLossPerc(30)
+	enc.SetInBandFEC(1)
+
+	dec, err := NewDecoder(SAMPLE_RATE, 1)
+	if err != nil || dec == nil {
+		t.Fatalf("Error creating new decoder: %v", err)
+	}
+
+	mono := make([]int16, FRAME_SIZE)
+	addSine(mono, SAMPLE_RATE, G4)
+
+	encodedData := make([][]byte, FRAME_SIZE/PACKET_SIZE)
+	for i, idx := 0, 0; i < len(mono); i += PACKET_SIZE {
+		data := make([]byte, 1000)
+		n, err := enc.Encode(mono[i:i+PACKET_SIZE], data)
+		if err != nil {
+			t.Fatalf("Couldn't encode data: %v", err)
+		}
+		data = data[:n]
+		encodedData[idx] = data
+		idx++
+	}
+
+	lost := false
+	for i := 0; i < len(encodedData); i++ {
+		// "Dropping" packets 2 and 4
+		if i == 2 || i == 4 {
+			lost = true
+			continue
+		}
+		if lost {
+			samples, err := dec.LastPacketDuration()
+			if err != nil {
+				t.Fatalf("Couldn't get last packet duration: %v", err)
+			}
+
+			pcmBuffer := make([]int16, samples)
+			if err = dec.DecodeFEC(encodedData[i], pcmBuffer); err != nil {
+				t.Fatalf("Couldn't decode data: %v", err)
+			}
+			pcm = append(pcm, pcmBuffer...)
+			lost = false
+		}
+
+		pcmBuffer := make([]int16, FRAME_SIZE)
+		n, err := dec.Decode(encodedData[i], pcmBuffer)
+		if err != nil {
+			t.Fatalf("Couldn't decode data: %v", err)
+		}
+		pcmBuffer = pcmBuffer[:n]
+		if len(pcmBuffer) != n {
+			t.Fatalf("Length mismatch: %d samples in, %d out", len(pcmBuffer), n)
+		}
+		pcm = append(pcm, pcmBuffer...)
+	}
+
+	if len(mono) != len(pcm) {
+		t.Fatalf("Input/Output length mismatch: %d samples in, %d out", len(mono), len(pcm))
+	}
+
+	// This is hard to check programatically, but I plotted the graphs in a
+	// spreadsheet and it looked great. The encoded waves both start out with a
+	// string of zero samples before they pick up, and the G4 is phase shifted
+	// by half a period, but that's all fine for lossy audio encoding.
+
+	//fmt.Printf("in,out\n")
+	//for i := range mono {
+	//	fmt.Printf("%d,%d\n", mono[i], pcm[i])
+	//}
+}
+
 func TestCodecFloat32(t *testing.T) {
 	// Create bogus input sound
 	const G4 = 391.995

--- a/opus_test.go
+++ b/opus_test.go
@@ -154,7 +154,7 @@ func TestCodecFEC(t *testing.T) {
 			t.Fatalf("Couldn't decode data: %v", err)
 		}
 		pcmBuffer = pcmBuffer[:n]
-		if len(pcmBuffer) != n {
+		if n != FRAME_SIZE {
 			t.Fatalf("Length mismatch: %d samples in, %d out", len(pcmBuffer), n)
 		}
 		pcm = append(pcm, pcmBuffer...)
@@ -237,7 +237,7 @@ func TestCodecFECFloat32(t *testing.T) {
 			t.Fatalf("Couldn't decode data: %v", err)
 		}
 		pcmBuffer = pcmBuffer[:n]
-		if len(pcmBuffer) != n {
+		if n != FRAME_SIZE {
 			t.Fatalf("Length mismatch: %d samples in, %d out", len(pcmBuffer), n)
 		}
 		pcm = append(pcm, pcmBuffer...)

--- a/opus_test.go
+++ b/opus_test.go
@@ -164,11 +164,7 @@ func TestCodecFEC(t *testing.T) {
 		t.Fatalf("Input/Output length mismatch: %d samples in, %d out", len(mono), len(pcm))
 	}
 
-	// This is hard to check programatically, but I plotted the graphs in a
-	// spreadsheet and it looked great. The encoded waves both start out with a
-	// string of zero samples before they pick up, and the G4 is phase shifted
-	// by half a period, but that's all fine for lossy audio encoding.
-
+	// Commented out for the same reason as in TestStereo
 	/*
 		fmt.Printf("in,out\n")
 		for i := range mono {
@@ -250,11 +246,7 @@ func TestCodecFECFloat32(t *testing.T) {
 		t.Fatalf("Input/Output length mismatch: %d samples in, %d out", len(mono), len(pcm))
 	}
 
-	// This is hard to check programatically, but I plotted the graphs in a
-	// spreadsheet and it looked great. The encoded waves both start out with a
-	// string of zero samples before they pick up, and the G4 is phase shifted
-	// by half a period, but that's all fine for lossy audio encoding.
-
+	// Commented out for the same reason as in TestStereo
 	/*
 		fmt.Printf("in,out\n")
 		for i := 0; i < len(mono); i++ {

--- a/opus_test.go
+++ b/opus_test.go
@@ -105,7 +105,7 @@ func TestCodecFEC(t *testing.T) {
 		t.Fatalf("Error creating new encoder: %v", err)
 	}
 	enc.SetPacketLossPerc(30)
-	enc.SetInBandFEC(1)
+	enc.SetInBandFEC(true)
 
 	dec, err := NewDecoder(SAMPLE_RATE, 1)
 	if err != nil || dec == nil {
@@ -191,7 +191,7 @@ func TestCodecFECFloat32(t *testing.T) {
 		t.Fatalf("Error creating new encoder: %v", err)
 	}
 	enc.SetPacketLossPerc(30)
-	enc.SetInBandFEC(1)
+	enc.SetInBandFEC(true)
 
 	dec, err := NewDecoder(SAMPLE_RATE, 1)
 	if err != nil || dec == nil {

--- a/opus_test.go
+++ b/opus_test.go
@@ -155,7 +155,7 @@ func TestCodecFEC(t *testing.T) {
 		}
 		pcmBuffer = pcmBuffer[:n]
 		if n != FRAME_SIZE {
-			t.Fatalf("Length mismatch: %d samples in, %d out", len(pcmBuffer), n)
+			t.Fatalf("Length mismatch: %d samples expected, %d out", FRAME_SIZE, n)
 		}
 		pcm = append(pcm, pcmBuffer...)
 	}
@@ -238,7 +238,7 @@ func TestCodecFECFloat32(t *testing.T) {
 		}
 		pcmBuffer = pcmBuffer[:n]
 		if n != FRAME_SIZE {
-			t.Fatalf("Length mismatch: %d samples in, %d out", len(pcmBuffer), n)
+			t.Fatalf("Length mismatch: %d samples expected, %d out", FRAME_SIZE, n)
 		}
 		pcm = append(pcm, pcmBuffer...)
 	}

--- a/opus_test.go
+++ b/opus_test.go
@@ -95,9 +95,9 @@ func TestCodecFEC(t *testing.T) {
 	// Create bogus input sound
 	const G4 = 391.995
 	const SAMPLE_RATE = 48000
-	const FRAME_SIZE_MS = 60
+	const FRAME_SIZE_MS = 10
 	const FRAME_SIZE = SAMPLE_RATE * FRAME_SIZE_MS / 1000
-	const PACKET_SIZE = 480 // 10ms packet
+	const NUMBER_OF_FRAMES = 6
 	pcm := make([]int16, 0)
 
 	enc, err := NewEncoder(SAMPLE_RATE, 1, AppVoIP)
@@ -112,13 +112,13 @@ func TestCodecFEC(t *testing.T) {
 		t.Fatalf("Error creating new decoder: %v", err)
 	}
 
-	mono := make([]int16, FRAME_SIZE)
+	mono := make([]int16, FRAME_SIZE*NUMBER_OF_FRAMES)
 	addSine(mono, SAMPLE_RATE, G4)
 
-	encodedData := make([][]byte, FRAME_SIZE/PACKET_SIZE)
-	for i, idx := 0, 0; i < len(mono); i += PACKET_SIZE {
+	encodedData := make([][]byte, NUMBER_OF_FRAMES)
+	for i, idx := 0, 0; i < len(mono); i += FRAME_SIZE {
 		data := make([]byte, 1000)
-		n, err := enc.Encode(mono[i:i+PACKET_SIZE], data)
+		n, err := enc.Encode(mono[i:i+FRAME_SIZE], data)
 		if err != nil {
 			t.Fatalf("Couldn't encode data: %v", err)
 		}
@@ -148,7 +148,7 @@ func TestCodecFEC(t *testing.T) {
 			lost = false
 		}
 
-		pcmBuffer := make([]int16, FRAME_SIZE)
+		pcmBuffer := make([]int16, NUMBER_OF_FRAMES*FRAME_SIZE)
 		n, err := dec.Decode(encodedData[i], pcmBuffer)
 		if err != nil {
 			t.Fatalf("Couldn't decode data: %v", err)
@@ -171,15 +171,16 @@ func TestCodecFEC(t *testing.T) {
 			fmt.Printf("%d,%d\n", mono[i], pcm[i])
 		}
 	*/
+
 }
 
 func TestCodecFECFloat32(t *testing.T) {
 	// Create bogus input sound
 	const G4 = 391.995
 	const SAMPLE_RATE = 48000
-	const FRAME_SIZE_MS = 60
+	const FRAME_SIZE_MS = 10
 	const FRAME_SIZE = SAMPLE_RATE * FRAME_SIZE_MS / 1000
-	const PACKET_SIZE = 480 // 10ms packet
+	const NUMBER_OF_FRAMES = 6
 	pcm := make([]float32, 0)
 
 	enc, err := NewEncoder(SAMPLE_RATE, 1, AppVoIP)
@@ -194,13 +195,13 @@ func TestCodecFECFloat32(t *testing.T) {
 		t.Fatalf("Error creating new decoder: %v", err)
 	}
 
-	mono := make([]float32, FRAME_SIZE)
+	mono := make([]float32, FRAME_SIZE*NUMBER_OF_FRAMES)
 	addSineFloat32(mono, SAMPLE_RATE, G4)
 
-	encodedData := make([][]byte, FRAME_SIZE/PACKET_SIZE)
-	for i, idx := 0, 0; i < len(mono); i += PACKET_SIZE {
+	encodedData := make([][]byte, NUMBER_OF_FRAMES)
+	for i, idx := 0, 0; i < len(mono); i += FRAME_SIZE {
 		data := make([]byte, 1000)
-		n, err := enc.EncodeFloat32(mono[i:i+PACKET_SIZE], data)
+		n, err := enc.EncodeFloat32(mono[i:i+FRAME_SIZE], data)
 		if err != nil {
 			t.Fatalf("Couldn't encode data: %v", err)
 		}
@@ -230,7 +231,7 @@ func TestCodecFECFloat32(t *testing.T) {
 			lost = false
 		}
 
-		pcmBuffer := make([]float32, FRAME_SIZE)
+		pcmBuffer := make([]float32, NUMBER_OF_FRAMES*FRAME_SIZE)
 		n, err := dec.DecodeFloat32(encodedData[i], pcmBuffer)
 		if err != nil {
 			t.Fatalf("Couldn't decode data: %v", err)


### PR DESCRIPTION
Issue: https://github.com/hraban/opus/issues/17
- Added relevant CTLs in encoder and decoder
- Added methods decodeFEC and decodeFECFloat32
- Added tests for all of those

For the FEC test, I manually "dropped" packets and used the csv with chart method using the code in the opus_test.go for visualizing the results. It looks good I think. 
I attached the graphs pictures.

![fec](https://user-images.githubusercontent.com/31823285/37893507-e69b2a78-30e3-11e8-9dc4-ce8ce68b7ac1.png)
![fec_32](https://user-images.githubusercontent.com/31823285/37893508-e6c5891c-30e3-11e8-86dc-00977ff34435.png)




