### PR TITLE
Conditionally disable libopusfile via a Go build tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Note regarding Forward Error Correction (FEC):
 > Note also that in order to use this feature the encoder needs to be configured
 > with `SetInBandFEC(true)` and `SetPacketLossPerc(x)` options.
 
-### Streams (and files)
+### Streams (and Files)
 
 To decode a .opus file (or .ogg with Opus data), or to decode a "Opus stream"
 (which is a Ogg stream with Opus data), use the `Stream` interface. It wraps an
@@ -180,12 +180,14 @@ Mac:
 brew install pkg-config opus opusfile
 ```
 
-### Build Tags
+### Building Without `libopusfile`
 
-This package can be built without depending on libopusfile by using the build tag
-`nolibopusfile`. This enables statically-linked binaries with no external
+This package can be built without `libopusfile` by using the build tag `nolibopusfile`.
+This enables the compilation of statically-linked binaries with no external
 dependencies on operating systems without a static `libopusfile`, such as
 [Alpine Linux](https://pkgs.alpinelinux.org/contents?branch=edge&name=opusfile-dev&arch=x86_64&repo=main).
+
+**Note:** this will disable all file and `Stream` APIs.
 
 To enable this feature, add `-tags nolibopusfile` to your `go build` or `go test` commands:
 
@@ -196,8 +198,6 @@ go build -tags nolibopusfile ...
 # Test
 go test -tags nolibopusfile ./...
 ```
-
-**Note:** this will disable all file and `Stream` APIs.
 
 ### Using in Docker
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ https://www.opus-codec.org/docs/opus_api-1.1.3/
 
 For more examples, see the `_test.go` files.
 
-## Build & installation
+## Build & Installation
 
 This package requires libopus and libopusfile development packages to be
 installed on your system. These are available on Debian based systems from
@@ -180,14 +180,24 @@ Mac:
 brew install pkg-config opus opusfile
 ```
 
-### Build tags
+### Build Tags
 
 This package can be built without depending on libopusfile by using the build tag
-`nolibopusfile`. For example:
+`nolibopusfile`. This enables statically-linked binaries with no external
+dependencies on operating systems without a static `libopusfile`, such as
+[Alpine Linux](https://pkgs.alpinelinux.org/contents?branch=edge&name=opusfile-dev&arch=x86_64&repo=main).
+
+To enable this feature, add `-tags nolibopusfile` to your `go build` or `go test` commands:
 
 ```sh
+# Build
 go build -tags nolibopusfile ...
+
+# Test
+go test -tags nolibopusfile ./...
 ```
+
+**Note:** this will disable all file and `Stream` APIs.
 
 ### Using in Docker
 

--- a/README.md
+++ b/README.md
@@ -180,6 +180,15 @@ Mac:
 brew install pkg-config opus opusfile
 ```
 
+### Build tags
+
+This package can be built without depending on libopusfile by using the build tag
+`nolibopusfile`. For example:
+
+```sh
+go build -tags nolibopusfile ...
+```
+
 ### Using in Docker
 
 If your Dockerized app has this library as a dependency (directly or

--- a/callbacks.c
+++ b/callbacks.c
@@ -1,3 +1,5 @@
+// +build !nolibopusfile
+
 // Copyright © 2015-2017 Go Opus Authors (see AUTHORS file)
 //
 // License for use of this code is detailed in the LICENSE file

--- a/errors.go
+++ b/errors.go
@@ -9,9 +9,8 @@ import (
 )
 
 /*
-#cgo pkg-config: opus opusfile
+#cgo pkg-config: opus
 #include <opus.h>
-#include <opusfile.h>
 */
 import "C"
 
@@ -34,65 +33,4 @@ const (
 // Error string (in human readable format) for libopus errors.
 func (e Error) Error() string {
 	return fmt.Sprintf("opus: %s", C.GoString(C.opus_strerror(C.int(e))))
-}
-
-type StreamError int
-
-var _ error = StreamError(0)
-
-// Libopusfile errors. The names are copied verbatim from the libopusfile
-// library.
-const (
-	ErrStreamFalse        = StreamError(C.OP_FALSE)
-	ErrStreamEOF          = StreamError(C.OP_EOF)
-	ErrStreamHole         = StreamError(C.OP_HOLE)
-	ErrStreamRead         = StreamError(C.OP_EREAD)
-	ErrStreamFault        = StreamError(C.OP_EFAULT)
-	ErrStreamImpl         = StreamError(C.OP_EIMPL)
-	ErrStreamInval        = StreamError(C.OP_EINVAL)
-	ErrStreamNotFormat    = StreamError(C.OP_ENOTFORMAT)
-	ErrStreamBadHeader    = StreamError(C.OP_EBADHEADER)
-	ErrStreamVersion      = StreamError(C.OP_EVERSION)
-	ErrStreamNotAudio     = StreamError(C.OP_ENOTAUDIO)
-	ErrStreamBadPacked    = StreamError(C.OP_EBADPACKET)
-	ErrStreamBadLink      = StreamError(C.OP_EBADLINK)
-	ErrStreamNoSeek       = StreamError(C.OP_ENOSEEK)
-	ErrStreamBadTimestamp = StreamError(C.OP_EBADTIMESTAMP)
-)
-
-func (i StreamError) Error() string {
-	switch i {
-	case ErrStreamFalse:
-		return "OP_FALSE"
-	case ErrStreamEOF:
-		return "OP_EOF"
-	case ErrStreamHole:
-		return "OP_HOLE"
-	case ErrStreamRead:
-		return "OP_EREAD"
-	case ErrStreamFault:
-		return "OP_EFAULT"
-	case ErrStreamImpl:
-		return "OP_EIMPL"
-	case ErrStreamInval:
-		return "OP_EINVAL"
-	case ErrStreamNotFormat:
-		return "OP_ENOTFORMAT"
-	case ErrStreamBadHeader:
-		return "OP_EBADHEADER"
-	case ErrStreamVersion:
-		return "OP_EVERSION"
-	case ErrStreamNotAudio:
-		return "OP_ENOTAUDIO"
-	case ErrStreamBadPacked:
-		return "OP_EBADPACKET"
-	case ErrStreamBadLink:
-		return "OP_EBADLINK"
-	case ErrStreamNoSeek:
-		return "OP_ENOSEEK"
-	case ErrStreamBadTimestamp:
-		return "OP_EBADTIMESTAMP"
-	default:
-		return "libopusfile error: %d (unknown code)"
-	}
 }

--- a/stream.go
+++ b/stream.go
@@ -2,6 +2,8 @@
 //
 // License for use of this code is detailed in the LICENSE file
 
+// +build !nolibopusfile
+
 package opus
 
 import (

--- a/stream_errors.go
+++ b/stream_errors.go
@@ -1,0 +1,75 @@
+// Copyright © 2015-2017 Go Opus Authors (see AUTHORS file)
+//
+// License for use of this code is detailed in the LICENSE file
+
+// +build !nolibopusfile
+
+package opus
+
+/*
+#cgo pkg-config: opusfile
+#include <opusfile.h>
+*/
+import "C"
+
+// StreamError represents an error from libopusfile.
+type StreamError int
+
+var _ error = StreamError(0)
+
+// Libopusfile errors. The names are copied verbatim from the libopusfile
+// library.
+const (
+	ErrStreamFalse        = StreamError(C.OP_FALSE)
+	ErrStreamEOF          = StreamError(C.OP_EOF)
+	ErrStreamHole         = StreamError(C.OP_HOLE)
+	ErrStreamRead         = StreamError(C.OP_EREAD)
+	ErrStreamFault        = StreamError(C.OP_EFAULT)
+	ErrStreamImpl         = StreamError(C.OP_EIMPL)
+	ErrStreamInval        = StreamError(C.OP_EINVAL)
+	ErrStreamNotFormat    = StreamError(C.OP_ENOTFORMAT)
+	ErrStreamBadHeader    = StreamError(C.OP_EBADHEADER)
+	ErrStreamVersion      = StreamError(C.OP_EVERSION)
+	ErrStreamNotAudio     = StreamError(C.OP_ENOTAUDIO)
+	ErrStreamBadPacked    = StreamError(C.OP_EBADPACKET)
+	ErrStreamBadLink      = StreamError(C.OP_EBADLINK)
+	ErrStreamNoSeek       = StreamError(C.OP_ENOSEEK)
+	ErrStreamBadTimestamp = StreamError(C.OP_EBADTIMESTAMP)
+)
+
+func (i StreamError) Error() string {
+	switch i {
+	case ErrStreamFalse:
+		return "OP_FALSE"
+	case ErrStreamEOF:
+		return "OP_EOF"
+	case ErrStreamHole:
+		return "OP_HOLE"
+	case ErrStreamRead:
+		return "OP_EREAD"
+	case ErrStreamFault:
+		return "OP_EFAULT"
+	case ErrStreamImpl:
+		return "OP_EIMPL"
+	case ErrStreamInval:
+		return "OP_EINVAL"
+	case ErrStreamNotFormat:
+		return "OP_ENOTFORMAT"
+	case ErrStreamBadHeader:
+		return "OP_EBADHEADER"
+	case ErrStreamVersion:
+		return "OP_EVERSION"
+	case ErrStreamNotAudio:
+		return "OP_ENOTAUDIO"
+	case ErrStreamBadPacked:
+		return "OP_EBADPACKET"
+	case ErrStreamBadLink:
+		return "OP_EBADLINK"
+	case ErrStreamNoSeek:
+		return "OP_ENOSEEK"
+	case ErrStreamBadTimestamp:
+		return "OP_EBADTIMESTAMP"
+	default:
+		return "libopusfile error: %d (unknown code)"
+	}
+}

--- a/stream_test.go
+++ b/stream_test.go
@@ -2,6 +2,8 @@
 //
 // License for use of this code is detailed in the LICENSE file
 
+// +build !nolibopusfile
+
 package opus
 
 import (

--- a/streams_map.go
+++ b/streams_map.go
@@ -2,6 +2,8 @@
 //
 // License for use of this code is detailed in the LICENSE file
 
+// +build !nolibopusfile
+
 package opus
 
 import (


### PR DESCRIPTION
This PR adds a new build tag `nolibopusfile` that conditionally compiles out the code that imports `libopusfile`. This enables a static binary build on Alpine Linux, which doesn’t have a static `libopusfile`.

Tests still work:

```sh
go test -tags nolibopusfile ./...
go test ./...
```