### PR TITLE
Fix memory corruption

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,3 +6,4 @@ Hraban Luyat <hraban@0brg.net>
 Dejian Xu <xudejian2008@gmail.com>
 Tobias Wellnitz <tobias.wellnitz@gmail.com>
 Elinor Natanzon <stop.start.dev@gmail.com>
+Victor Gaydov <victor@enise.org>

--- a/opus_test.go
+++ b/opus_test.go
@@ -307,3 +307,153 @@ func TestStereo(t *testing.T) {
 		}
 	*/
 }
+
+func TestBufferSize(t *testing.T) {
+	const G4 = 391.995
+	const SAMPLE_RATE = 48000
+	const FRAME_SIZE_MS = 60
+	const FRAME_SIZE = SAMPLE_RATE * FRAME_SIZE_MS / 1000
+	const GUARD_SIZE = 100
+
+	checkGuardInt16 := func(t *testing.T, s []int16) {
+		for n := range s {
+			if s[n] != 0 {
+				t.Fatal("Memory corruption detected")
+			}
+		}
+	}
+
+	checkGuardFloat32 := func(t *testing.T, s []float32) {
+		for n := range s {
+			if s[n] != 0 {
+				t.Fatal("Memory corruption detected")
+			}
+		}
+	}
+
+	checkResult := func(t *testing.T, n int, err error, expectOK bool) {
+		if expectOK {
+			if err != nil {
+				t.Fatalf("Couldn't decode data: %v", err)
+			}
+			if n != FRAME_SIZE {
+				t.Fatalf("Length mismatch: %d samples in, %d out", FRAME_SIZE, n)
+			}
+		} else {
+			if err == nil {
+				t.Fatalf("Expected decode failure, but it succeeded")
+			}
+		}
+	}
+
+	encodeFrame := func(t *testing.T) []byte {
+		pcm := make([]int16, FRAME_SIZE)
+		enc, err := NewEncoder(SAMPLE_RATE, 1, AppVoIP)
+		if err != nil || enc == nil {
+			t.Fatalf("Error creating new encoder: %v", err)
+		}
+		addSine(pcm, SAMPLE_RATE, G4)
+		data := make([]byte, 1000)
+		n, err := enc.Encode(pcm, data)
+		if err != nil {
+			t.Fatalf("Couldn't encode data: %v", err)
+		}
+		return data[:n]
+	}
+
+	createDecoder := func(t *testing.T) *Decoder {
+		dec, err := NewDecoder(SAMPLE_RATE, 1)
+		if err != nil || dec == nil {
+			t.Fatalf("Error creating new decoder: %v", err)
+		}
+		return dec
+	}
+
+	decodeInt16 := func(t *testing.T, data []byte, decodeSize int, expectOK bool) {
+		dec := createDecoder(t)
+		decodedMem := make([]int16, decodeSize+GUARD_SIZE*2)
+		decodedRef := decodedMem[GUARD_SIZE : GUARD_SIZE+decodeSize : GUARD_SIZE+decodeSize]
+		n, err := dec.Decode(data, decodedRef)
+		checkGuardInt16(t, decodedMem[:GUARD_SIZE])
+		checkGuardInt16(t, decodedMem[decodeSize+GUARD_SIZE:])
+		checkResult(t, n, err, expectOK)
+	}
+
+	decodeFloat32 := func(t *testing.T, data []byte, decodeSize int, expectOK bool) {
+		dec := createDecoder(t)
+		decodedMem := make([]float32, decodeSize+GUARD_SIZE*2)
+		decodedRef := decodedMem[GUARD_SIZE : GUARD_SIZE+decodeSize : GUARD_SIZE+decodeSize]
+		n, err := dec.DecodeFloat32(data, decodedRef)
+		checkGuardFloat32(t, decodedMem[:GUARD_SIZE])
+		checkGuardFloat32(t, decodedMem[decodeSize+GUARD_SIZE:])
+		checkResult(t, n, err, expectOK)
+	}
+
+	decodeFecInt16 := func(t *testing.T, data []byte, decodeSize int, expectOK bool) {
+		dec := createDecoder(t)
+		decodedMem := make([]int16, decodeSize+GUARD_SIZE*2)
+		decodedRef := decodedMem[GUARD_SIZE : GUARD_SIZE+decodeSize : GUARD_SIZE+decodeSize]
+		err := dec.DecodeFEC(data, decodedRef)
+		checkGuardInt16(t, decodedMem[:GUARD_SIZE])
+		checkGuardInt16(t, decodedMem[decodeSize+GUARD_SIZE:])
+		checkResult(t, FRAME_SIZE, err, expectOK)
+	}
+
+	decodeFecFloat32 := func(t *testing.T, data []byte, decodeSize int, expectOK bool) {
+		dec := createDecoder(t)
+		decodedMem := make([]float32, decodeSize+GUARD_SIZE*2)
+		decodedRef := decodedMem[GUARD_SIZE : GUARD_SIZE+decodeSize : GUARD_SIZE+decodeSize]
+		err := dec.DecodeFECFloat32(data, decodedRef)
+		checkGuardFloat32(t, decodedMem[:GUARD_SIZE])
+		checkGuardFloat32(t, decodedMem[decodeSize+GUARD_SIZE:])
+		checkResult(t, FRAME_SIZE, err, expectOK)
+	}
+
+	t.Run("smaller-buffer-int16", func(t *testing.T) {
+		decodeInt16(t, encodeFrame(t), FRAME_SIZE-1, false)
+	})
+
+	t.Run("smaller-buffer-float32", func(t *testing.T) {
+		decodeFloat32(t, encodeFrame(t), FRAME_SIZE-1, false)
+	})
+
+	t.Run("smaller-buffer-int16-fec", func(t *testing.T) {
+		decodeFecFloat32(t, encodeFrame(t), FRAME_SIZE-1, false)
+	})
+
+	t.Run("smaller-buffer-float32-fec", func(t *testing.T) {
+		decodeFecFloat32(t, encodeFrame(t), FRAME_SIZE-1, false)
+	})
+
+	t.Run("exact-buffer-int16", func(t *testing.T) {
+		decodeInt16(t, encodeFrame(t), FRAME_SIZE, true)
+	})
+
+	t.Run("exact-buffer-float32", func(t *testing.T) {
+		decodeFloat32(t, encodeFrame(t), FRAME_SIZE, true)
+	})
+
+	t.Run("exact-buffer-int16-fec", func(t *testing.T) {
+		decodeFecInt16(t, encodeFrame(t), FRAME_SIZE, true)
+	})
+
+	t.Run("exact-buffer-float32-fec", func(t *testing.T) {
+		decodeFecFloat32(t, encodeFrame(t), FRAME_SIZE, true)
+	})
+
+	t.Run("larger-buffer-int16", func(t *testing.T) {
+		decodeInt16(t, encodeFrame(t), FRAME_SIZE+1, true)
+	})
+
+	t.Run("larger-buffer-float32", func(t *testing.T) {
+		decodeFloat32(t, encodeFrame(t), FRAME_SIZE+1, true)
+	})
+
+	t.Run("larger-buffer-int16-fec", func(t *testing.T) {
+		decodeFecInt16(t, encodeFrame(t), FRAME_SIZE+1, false)
+	})
+
+	t.Run("larger-buffer-float32-fec", func(t *testing.T) {
+		decodeFecFloat32(t, encodeFrame(t), FRAME_SIZE+1, false)
+	})
+}


### PR DESCRIPTION
Hi and thanks for sharing this library.

Currently, all decode methods have two problems:

1. They pass to opus_decode() the total number of samples in output buffer. But according to [documentation](https://www.opus-codec.org/docs/html_api/group__opusdecoder.html#ga1a8b923c1041ad4976ceada237e117ba), they should pass number of samples *per channel*. In result, in two-channel mode opus will think that the buffer is twice larger than it is. This may lead to memory corruption which is actually reproducing in my application. It's not reproduced each time. It seems that opus usually determines the frame size from its contents and doesn't touch the memory beyond that size.

2. They use cap() instead of len(). I believe this is a bad decision for API because if I pass `data[:n]` to a function, I expect that the memory beyond `n` will not be touched. But with current API it may happen if the slice capacity is larger than the slice length. Such bugs may be very hard to find, especially if your slice comes from some other component and refers to a part of a larger memory region (e.g. in pool).

This patch fixes both issues. If you don't agree with the second point, which may be arguable, I can revert the second part of the fix and use cap() instead of len().

I've also added a test. This test fails before applying the patch and succeeds after applying it.