### PR TITLE
Add DecodePLC

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,18 @@ Note regarding Forward Error Correction (FEC):
 > Note also that in order to use this feature the encoder needs to be configured
 > with `SetInBandFEC(true)` and `SetPacketLossPerc(x)` options.
 
+Note regarding Packet Loss Concealment (PLC):
+> When a packet is considered "lost", `DecodePLC` and `DecodePLCFloat32` methods
+> can be called in order to obtain something better sounding than just silence.
+> The PCM needs to be exactly the duration of audio that is missing.
+> `LastPacketDuration()` can be used on the decoder to get the length of the
+> last packet.
+> This option does not require any additional encoder options. Unlike FEC,
+> PLC does not introduce additional latency. It is calculated from the previous
+> packet, not from the next one.
+> Note that `DecodeFEC` and `DecodeFECFloat32` automatically fall back to PLC
+> when no FEC data is available in the provided packet.
+
 ### Streams (and files)
 
 To decode a .opus file (or .ogg with Opus data), or to decode a "Opus stream"

--- a/decoder.go
+++ b/decoder.go
@@ -64,7 +64,7 @@ func (dec *Decoder) Init(sample_rate int, channels int) error {
 	return nil
 }
 
-// Decode encoded Opus data into the supplied buffer. On success, returns the
+// Decode decodes Opus data into the supplied buffer. On success, returns the
 // number of samples correctly written to the target buffer.
 func (dec *Decoder) Decode(data []byte, pcm []int16) (int, error) {
 	if dec.p == nil {
@@ -92,7 +92,7 @@ func (dec *Decoder) Decode(data []byte, pcm []int16) (int, error) {
 	return n, nil
 }
 
-// Decode encoded Opus data into the supplied buffer. On success, returns the
+// Decode decodes Opus data into the supplied buffer. On success, returns the
 // number of samples correctly written to the target buffer.
 func (dec *Decoder) DecodeFloat32(data []byte, pcm []float32) (int, error) {
 	if dec.p == nil {
@@ -120,7 +120,7 @@ func (dec *Decoder) DecodeFloat32(data []byte, pcm []float32) (int, error) {
 	return n, nil
 }
 
-// DecodeFEC encoded Opus data into the supplied buffer with forward error
+// DecodeFEC decodes Opus data into the supplied buffer with forward error
 // correction. It is to be used on the packet directly following the lost one.
 // The supplied buffer needs to be exactly the duration of audio that is missing
 func (dec *Decoder) DecodeFEC(data []byte, pcm []int16) error {
@@ -149,7 +149,7 @@ func (dec *Decoder) DecodeFEC(data []byte, pcm []int16) error {
 	return nil
 }
 
-// DecodeFECFloat32 encoded Opus data into the supplied buffer with forward error
+// DecodeFECFloat32 decodes Opus data into the supplied buffer with forward error
 // correction. It is to be used on the packet directly following the lost one.
 // The supplied buffer needs to be exactly the duration of audio that is missing
 func (dec *Decoder) DecodeFECFloat32(data []byte, pcm []float32) error {

--- a/decoder.go
+++ b/decoder.go
@@ -178,6 +178,56 @@ func (dec *Decoder) DecodeFECFloat32(data []byte, pcm []float32) error {
 	return nil
 }
 
+// DecodePLC recovers a lost packet using Opus Packet Loss Concealment feature.
+// The supplied buffer needs to be exactly the duration of audio that is missing.
+func (dec *Decoder) DecodePLC(pcm []int16) error {
+	if dec.p == nil {
+		return errDecUninitialized
+	}
+	if len(pcm) == 0 {
+		return fmt.Errorf("opus: target buffer empty")
+	}
+	if cap(pcm)%dec.channels != 0 {
+		return fmt.Errorf("opus: output buffer capacity must be multiple of channels")
+	}
+	n := int(C.opus_decode(
+		dec.p,
+		nil,
+		0,
+		(*C.opus_int16)(&pcm[0]),
+		C.int(cap(pcm)/dec.channels),
+		0))
+	if n < 0 {
+		return Error(n)
+	}
+	return nil
+}
+
+// DecodePLCFloat32 recovers a lost packet using Opus Packet Loss Concealment feature.
+// The supplied buffer needs to be exactly the duration of audio that is missing.
+func (dec *Decoder) DecodePLCFloat32(pcm []float32) error {
+	if dec.p == nil {
+		return errDecUninitialized
+	}
+	if len(pcm) == 0 {
+		return fmt.Errorf("opus: target buffer empty")
+	}
+	if cap(pcm)%dec.channels != 0 {
+		return fmt.Errorf("opus: output buffer capacity must be multiple of channels")
+	}
+	n := int(C.opus_decode_float(
+		dec.p,
+		nil,
+		0,
+		(*C.float)(&pcm[0]),
+		C.int(cap(pcm)/dec.channels),
+		0))
+	if n < 0 {
+		return Error(n)
+	}
+	return nil
+}
+
 // LastPacketDuration gets the duration (in samples)
 // of the last packet successfully decoded or concealed.
 func (dec *Decoder) LastPacketDuration() (int, error) {


### PR DESCRIPTION
Provide explicit access to Opus PLC.

DecodeFEC automatically falls back to PLC when FEC is not available, but DecodeFEC can be used only when next packet arrived.

DecodePLC calls opus_decode with NULL data which is a form to explicitly request PLC. It can be used even when no packets arrived yet. 