### PR TITLE
feat: Implement InDTX for Encoder

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -26,6 +26,12 @@ bridge_encoder_get_dtx(OpusEncoder *st, opus_int32 *dtx)
 }
 
 int
+bridge_encoder_get_in_dtx(OpusEncoder *st, opus_int32 *in_dtx)
+{
+	return opus_encoder_ctl(st, OPUS_GET_IN_DTX(in_dtx));
+}
+
+int
 bridge_encoder_get_sample_rate(OpusEncoder *st, opus_int32 *sample_rate)
 {
 	return opus_encoder_ctl(st, OPUS_GET_SAMPLE_RATE(sample_rate));
@@ -237,6 +243,17 @@ func (enc *Encoder) DTX() (bool, error) {
 		return false, Error(res)
 	}
 	return dtx != 0, nil
+}
+
+// InDTX returns whether the last encoded frame was either a comfort noise update
+// during DTX or not encoded because of DTX.
+func (enc *Encoder) InDTX() (bool, error) {
+	var inDTX C.opus_int32
+	res := C.bridge_encoder_get_in_dtx(enc.p, &inDTX)
+	if res != C.OPUS_OK {
+		return false, Error(res)
+	}
+	return inDTX != 0, nil
 }
 
 // SampleRate returns the encoder sample rate in Hz.


### PR DESCRIPTION
This implements a wrapper for the Generic CTL [OPUS_GET_IN_DTX](https://opus-codec.org/docs/opus_api-1.3.1/group__opus__genericctls.html#ga9af68dcfb4f136dd91b1050658d559ca). This is used when encoding frames to determine whether the most recently encoded frame was either skipped or comfort noise due to DTX.

For motivation on what this might be used for, see [this](https://source.chromium.org/chromium/chromium/src/+/refs/heads/main:third_party/webrtc/modules/audio_coding/codecs/opus/opus_interface.cc;l=82) and [this](https://source.chromium.org/chromium/chromium/src/+/refs/heads/main:third_party/webrtc/modules/audio_coding/codecs/opus/opus_interface.cc;l=248) in Chrome's WebRTC implementation.

For my particular use case, it is for testing purposes (writing tests that ensure DTX is handled appropriately on the receiver; it is useful to have a way to definitely check whether a packet was DTX without parsing it to find whether frame lengths were all 0).