### PR TITLE
Added SetComplexity to decoder

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -18,6 +18,12 @@ bridge_decoder_get_last_packet_duration(OpusDecoder *st, opus_int32 *samples)
 {
 	return opus_decoder_ctl(st, OPUS_GET_LAST_PACKET_DURATION(samples));
 }
+
+int
+bridge_decoder_set_complexity(OpusDecoder *st, opus_int32 complexity)
+{
+	return opus_decoder_ctl(st, OPUS_SET_COMPLEXITY(complexity));
+}
 */
 import "C"
 
@@ -259,4 +265,15 @@ func (dec *Decoder) LastPacketDuration() (int, error) {
 		return 0, Error(res)
 	}
 	return int(samples), nil
+}
+
+// SetComplexity sets the decoders's computational complexity
+// Note that this feature is only available if using libopus >= 1.5
+// This function will return ErrUnimplemented if the feature is not available
+func (enc *Decoder) SetComplexity(complexity int) error {
+	res := C.bridge_decoder_set_complexity(enc.p, C.opus_int32(complexity))
+	if res != C.OPUS_OK {
+		return Error(res)
+	}
+	return nil
 }

--- a/decoder.go
+++ b/decoder.go
@@ -22,7 +22,7 @@ bridge_decoder_get_last_packet_duration(OpusDecoder *st, opus_int32 *samples)
 #define BRIDGE_ERR_NOT_SUPPORTED -12345
 
 int
-bridge_decoder_set_complexity(OpusDecoder *st, int complexity)
+bridge_decoder_set_complexity(OpusDecoder *st, opus_int32 complexity)
 {
 #if defined(OPUS_SET_COMPLEXITY)
 	return opus_decoder_ctl(st, OPUS_SET_COMPLEXITY(complexity));

--- a/decoder.go
+++ b/decoder.go
@@ -19,10 +19,15 @@ bridge_decoder_get_last_packet_duration(OpusDecoder *st, opus_int32 *samples)
 	return opus_decoder_ctl(st, OPUS_GET_LAST_PACKET_DURATION(samples));
 }
 
+#define BRIDGE_ERR_NOT_SUPPORTED -12345
+
 int
-bridge_decoder_set_complexity(OpusDecoder *st, opus_int32 complexity)
+bridge_decoder_set_complexity(OpusDecoder *st, int complexity)
 {
+#if defined(OPUS_SET_COMPLEXITY)
 	return opus_decoder_ctl(st, OPUS_SET_COMPLEXITY(complexity));
+#endif
+	return BRIDGE_ERR_NOT_SUPPORTED;
 }
 */
 import "C"
@@ -267,12 +272,16 @@ func (dec *Decoder) LastPacketDuration() (int, error) {
 	return int(samples), nil
 }
 
+const bridgeErrUnimplemented = C.BRIDGE_ERR_NOT_SUPPORTED
+
 // SetComplexity sets the decoders's computational complexity
 // Note that this feature is only available if using libopus >= 1.5
-// This function will return ErrUnimplemented if the feature is not available
-func (enc *Decoder) SetComplexity(complexity int) error {
-	res := C.bridge_decoder_set_complexity(enc.p, C.opus_int32(complexity))
-	if res != C.OPUS_OK {
+func (dec *Decoder) SetComplexity(complexity int) error {
+	res := int(C.bridge_decoder_set_complexity(dec.p, C.int(complexity)))
+	if res == bridgeErrUnimplemented {
+		return fmt.Errorf("SetComplexity for decoders requires libopus 1.5 or higher")
+	}
+	if res != int(C.OPUS_OK) {
 		return Error(res)
 	}
 	return nil

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -5,6 +5,7 @@
 package opus
 
 import (
+	"fmt"
 	"testing"
 )
 
@@ -64,5 +65,32 @@ func TestDecoder_GetLastPacketDuration(t *testing.T) {
 	}
 	if samples != n {
 		t.Fatalf("Wrong duration length. Expected %d. Got %d", n, samples)
+	}
+}
+
+func TestDecoder_SetComplexity(t *testing.T) {
+	const SAMPLE_RATE = 48000
+
+	dec, err := NewDecoder(SAMPLE_RATE, 1)
+	if err != nil || dec == nil {
+		t.Fatalf("Error creating new decoder: %v", err)
+	}
+
+	t.Run("Complexity 0 to 10", func(t *testing.T) {
+		for i := 0; i <= 10; i++ {
+			err = dec.SetComplexity(i)
+			if err != nil {
+				t.Fatalf("Expected nil got %v", err)
+			}
+		}
+	})
+
+	for _, tt := range []int{-1, 11, 99} {
+		t.Run(fmt.Sprintf("Complexity %d", tt), func(t *testing.T) {
+			err = dec.SetComplexity(tt)
+			if err != ErrBadArg {
+				t.Fatalf("Expected %v got %v", ErrBadArg, err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
In order to support deep PLC, libopus added `OPUS_SET_COMPLEXITY()` to the decoder API. 

This PR adds SetComplexity method to the decoder.

Note that if libopus < 1.5 this function will return `ErrUnimplemented` so users could easily ignore it like this:

```
dec, err := opus.NewDecoder(48000, 1)
if err != nil {
	// ... handle error
}

err = dec.SetComplexity(10)
if err != nil && err != opus.ErrUnimplemented {
	// ... handle error
}
```