### PR TITLE
Add Support for Constant Bitrate (CBR) in Opus Encoder

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -104,6 +104,19 @@ bridge_encoder_reset_state(OpusEncoder *st)
 	return opus_encoder_ctl(st, OPUS_RESET_STATE);
 }
 
+int
+bridge_encoder_set_vbr(OpusEncoder *st, opus_int32 vbr)
+{
+	return opus_encoder_ctl(st, OPUS_SET_VBR(vbr));
+}
+
+int
+bridge_encoder_get_vbr(OpusEncoder *st, opus_int32 *vbr)
+{
+	return opus_encoder_ctl(st, OPUS_GET_VBR(vbr));
+}
+
+
 */
 import "C"
 
@@ -399,4 +412,27 @@ func (enc *Encoder) Reset() error {
 		return Error(res)
 	}
 	return nil
+}
+
+// SetCBR sets the encoder to use constant bitrate (CBR) or variable bitrate (VBR).
+func (enc *Encoder) SetCBR(cbr bool) error {
+	vbr := 1
+	if cbr {
+		vbr = 0
+	}
+	res := C.bridge_encoder_set_vbr(enc.p, C.opus_int32(vbr))
+	if res != C.OPUS_OK {
+		return Error(res)
+	}
+	return nil
+}
+
+// IsCBR checks if encoder is using CBR (false = VBR).
+func (enc *Encoder) IsCBR() (bool, error) {
+	var vbr C.opus_int32
+	res := C.bridge_encoder_get_vbr(enc.p, &vbr)
+	if res != C.OPUS_OK {
+		return false, Error(res)
+	}
+	return vbr == 0, nil
 }


### PR DESCRIPTION
### Feature: Add support for Constant Bitrate (CBR) control

This PR adds the ability to configure whether the Opus encoder uses constant bitrate (CBR) or variable bitrate (VBR), which was previously unavailable in this Go binding.

### Changes
- Introduced `SetCBR(cbr bool)` to switch between CBR and VBR.
- Introduced `IsCBR() (bool, error)` to query current setting.
- Added C bridge functions: `bridge_encoder_set_vbr` and `bridge_encoder_get_vbr`.

### Reason
Exposing this option allows developers to better control encoding behavior in constrained bitrate environments, particularly for VoIP or streaming use-cases.

### Notes
This is a non-breaking change and fully backward compatible.

Thanks for your work on this project!
